### PR TITLE
Implements `returning a text response` & `returning a HTML response` features

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,22 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Refactors `RequestHandler` to `RequestParser`. Uses builder pattern to create parsed `Request` objects." />
+    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Adds `private final` to Router declaration.">
+      <change afterPath="$PROJECT_DIR$/src/main/java/http/ContentTypes.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/http/Methods.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/http/routes/structured_data/TextResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/Router.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/Router.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/EchoBody.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/EchoBody.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions2.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions2.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/Redirect.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/Redirect.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGET.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGET.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGETWithBody.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGETWithBody.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/SimpleHEAD.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/SimpleHEAD.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/http/ResponseBuilderTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/http/ResponseBuilderTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/http/RouterTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/http/RouterTest.java" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -66,8 +81,8 @@
       <recent name="http" />
     </key>
     <key name="CopyClassDialog.RECENTS_KEY">
-      <recent name="http.routes" />
       <recent name="http" />
+      <recent name="http.routes" />
     </key>
   </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Implements `Scenario: Returning a HTML response` feature">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Removing unnecessary `CRLF` string from Routes." />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -279,7 +277,14 @@
       <option name="project" value="LOCAL" />
       <updated>1674055006819</updated>
     </task>
-    <option name="localTasksCounter" value="29" />
+    <task id="LOCAL-00029" summary="Removing unnecessary `CRLF` string from Routes.">
+      <created>1674128980243</created>
+      <option name="number" value="00029" />
+      <option name="presentableId" value="LOCAL-00029" />
+      <option name="project" value="LOCAL" />
+      <updated>1674128980243</updated>
+    </task>
+    <option name="localTasksCounter" value="30" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -297,7 +302,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Changed `InputOutput` to `TestClientInputOutput` to make it clear what this is for." />
     <MESSAGE value="Added Git submodule to include `http_server_spec` feature tests repo in the project. Updated README with instructions on how to run the test suite." />
     <MESSAGE value="Rename `responseString` to `statusCode` to better reflect its use." />
     <MESSAGE value="Rename WebServerTest to ResponseHandlerTest to better reflect its use." />
@@ -322,6 +326,7 @@
     <MESSAGE value="Refactors `RequestHandler` to `RequestParser`. Uses builder pattern to create parsed `Request` objects." />
     <MESSAGE value="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`" />
     <MESSAGE value="Implements `Scenario: Returning a HTML response` feature" />
-    <option name="LAST_COMMIT_MESSAGE" value="Implements `Scenario: Returning a HTML response` feature" />
+    <MESSAGE value="Removing unnecessary `CRLF` string from Routes." />
+    <option name="LAST_COMMIT_MESSAGE" value="Removing unnecessary `CRLF` string from Routes." />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Removing unnecessary `CRLF` string from Routes." />
+    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Bring backs simple class imports where IDE had changed to `*`" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -284,7 +284,14 @@
       <option name="project" value="LOCAL" />
       <updated>1674128980243</updated>
     </task>
-    <option name="localTasksCounter" value="30" />
+    <task id="LOCAL-00030" summary="Bring backs simple class imports where IDE had changed to `*`">
+      <created>1674129612150</created>
+      <option name="number" value="00030" />
+      <option name="presentableId" value="LOCAL-00030" />
+      <option name="project" value="LOCAL" />
+      <updated>1674129612150</updated>
+    </task>
+    <option name="localTasksCounter" value="31" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -302,7 +309,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Added Git submodule to include `http_server_spec` feature tests repo in the project. Updated README with instructions on how to run the test suite." />
     <MESSAGE value="Rename `responseString` to `statusCode` to better reflect its use." />
     <MESSAGE value="Rename WebServerTest to ResponseHandlerTest to better reflect its use." />
     <MESSAGE value="GET request to /simple_get_with_body returns a 200 with the body &quot;Hello world&quot;" />
@@ -327,6 +333,7 @@
     <MESSAGE value="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`" />
     <MESSAGE value="Implements `Scenario: Returning a HTML response` feature" />
     <MESSAGE value="Removing unnecessary `CRLF` string from Routes." />
-    <option name="LAST_COMMIT_MESSAGE" value="Removing unnecessary `CRLF` string from Routes." />
+    <MESSAGE value="Bring backs simple class imports where IDE had changed to `*`" />
+    <option name="LAST_COMMIT_MESSAGE" value="Bring backs simple class imports where IDE had changed to `*`" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,19 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Adds `private final` to Router declaration.">
-      <change afterPath="$PROJECT_DIR$/src/main/java/http/ContentTypes.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/http/Methods.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/http/routes/structured_data/TextResponse.java" afterDir="false" />
+    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`">
+      <change afterPath="$PROJECT_DIR$/src/main/java/http/routes/structured_data/HTMLResponse.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/http/ContentTypes.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/ContentTypes.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/http/Router.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/Router.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/EchoBody.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/EchoBody.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions2.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/MethodOptions2.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/Redirect.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/Redirect.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGET.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGET.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGETWithBody.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/SimpleGETWithBody.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/routes/SimpleHEAD.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/routes/SimpleHEAD.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/http/ResponseBuilderTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/http/ResponseBuilderTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/http/RouterTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/http/RouterTest.java" afterDir="false" />
     </list>
@@ -81,6 +73,7 @@
       <recent name="http" />
     </key>
     <key name="CopyClassDialog.RECENTS_KEY">
+      <recent name="http.routes.structured_data" />
       <recent name="http" />
       <recent name="http.routes" />
     </key>
@@ -277,7 +270,14 @@
       <option name="project" value="LOCAL" />
       <updated>1673980137692</updated>
     </task>
-    <option name="localTasksCounter" value="27" />
+    <task id="LOCAL-00027" summary="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`">
+      <created>1674045246841</created>
+      <option name="number" value="00027" />
+      <option name="presentableId" value="LOCAL-00027" />
+      <option name="project" value="LOCAL" />
+      <updated>1674045246841</updated>
+    </task>
+    <option name="localTasksCounter" value="28" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -295,7 +295,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Fixed port 5000 issue due to Mac Airplay receiver" />
     <MESSAGE value="Adds application details to `build.gradle` and logs HTTP requests to command line in preparation for parsing." />
     <MESSAGE value="Changed `InputOutput` to `TestClientInputOutput` to make it clear what this is for." />
     <MESSAGE value="Added Git submodule to include `http_server_spec` feature tests repo in the project. Updated README with instructions on how to run the test suite." />
@@ -320,6 +319,7 @@
     <MESSAGE value="Large refactor to implement a `ResponseBuilder`. The `ResponseBuilder` uses the builder pattern to return an object of the `Response` class." />
     <MESSAGE value="Implements a `Request` class with getters/setters to extract request parsing from the `ClientHandler`" />
     <MESSAGE value="Refactors `RequestHandler` to `RequestParser`. Uses builder pattern to create parsed `Request` objects." />
-    <option name="LAST_COMMIT_MESSAGE" value="Refactors `RequestHandler` to `RequestParser`. Uses builder pattern to create parsed `Request` objects." />
+    <MESSAGE value="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`" />
+    <option name="LAST_COMMIT_MESSAGE" value="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`">
-      <change afterPath="$PROJECT_DIR$/src/main/java/http/routes/structured_data/HTMLResponse.java" afterDir="false" />
+    <list default="true" id="b4254501-5f23-4dab-8f16-b42931b65262" name="Changes" comment="Implements `Scenario: Returning a HTML response` feature">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/ContentTypes.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/ContentTypes.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/http/Router.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/http/Router.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/http/ResponseBuilderTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/http/ResponseBuilderTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/http/RouterTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/http/RouterTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -277,7 +272,14 @@
       <option name="project" value="LOCAL" />
       <updated>1674045246841</updated>
     </task>
-    <option name="localTasksCounter" value="28" />
+    <task id="LOCAL-00028" summary="Implements `Scenario: Returning a HTML response` feature">
+      <created>1674055006819</created>
+      <option name="number" value="00028" />
+      <option name="presentableId" value="LOCAL-00028" />
+      <option name="project" value="LOCAL" />
+      <updated>1674055006819</updated>
+    </task>
+    <option name="localTasksCounter" value="29" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -295,7 +297,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Adds application details to `build.gradle` and logs HTTP requests to command line in preparation for parsing." />
     <MESSAGE value="Changed `InputOutput` to `TestClientInputOutput` to make it clear what this is for." />
     <MESSAGE value="Added Git submodule to include `http_server_spec` feature tests repo in the project. Updated README with instructions on how to run the test suite." />
     <MESSAGE value="Rename `responseString` to `statusCode` to better reflect its use." />
@@ -320,6 +321,7 @@
     <MESSAGE value="Implements a `Request` class with getters/setters to extract request parsing from the `ClientHandler`" />
     <MESSAGE value="Refactors `RequestHandler` to `RequestParser`. Uses builder pattern to create parsed `Request` objects." />
     <MESSAGE value="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`" />
-    <option name="LAST_COMMIT_MESSAGE" value="Implements `Scenario: Returning a text response` feature and introduces enums for `CONTENT_TYPES` and `METHODS`" />
+    <MESSAGE value="Implements `Scenario: Returning a HTML response` feature" />
+    <option name="LAST_COMMIT_MESSAGE" value="Implements `Scenario: Returning a HTML response` feature" />
   </component>
 </project>

--- a/src/main/java/http/ContentTypes.java
+++ b/src/main/java/http/ContentTypes.java
@@ -2,8 +2,11 @@ package http;
 
 public enum ContentTypes {
     CONTENT_TYPE("Content-Type: "),
-    CONTENT_TYPE_TEXT(CONTENT_TYPE.getType() + "text/plain;charset=utf-8");
+    CONTENT_TYPE_TEXT(CONTENT_TYPE.getType() + "text/plain;charset=utf-8"),
+    CONTENT_TYPE_HTML(CONTENT_TYPE.getType() + "text/html;charset=utf-8");
+
     private final String type;
+
     ContentTypes(String type) { this.type = type; }
     public String getType() { return type; }
 }

--- a/src/main/java/http/ContentTypes.java
+++ b/src/main/java/http/ContentTypes.java
@@ -1,0 +1,9 @@
+package http;
+
+public enum ContentTypes {
+    CONTENT_TYPE("Content-Type: "),
+    CONTENT_TYPE_TEXT(CONTENT_TYPE.getType() + "text/plain;charset=utf-8");
+    private final String type;
+    ContentTypes(String type) { this.type = type; }
+    public String getType() { return type; }
+}

--- a/src/main/java/http/Methods.java
+++ b/src/main/java/http/Methods.java
@@ -1,0 +1,14 @@
+package http;
+
+public enum Methods {
+    GET("GET"),
+    HEAD("HEAD"),
+    OPTIONS("OPTIONS"),
+    POST("POST"),
+    PUT("PUT");
+
+    private final String method;
+
+    Methods(String method) { this.method = method; }
+    public String getMethod() { return method; }
+}

--- a/src/main/java/http/Response.java
+++ b/src/main/java/http/Response.java
@@ -3,7 +3,6 @@ package http;
 public class Response {
     private final String statusCode;
     private final String header;
-
     private final String body;
 
     public Response(String statusCode, String header, String body) {

--- a/src/main/java/http/Router.java
+++ b/src/main/java/http/Router.java
@@ -1,6 +1,7 @@
 package http;
 
 import http.routes.*;
+import http.routes.structured_data.TextResponse;
 
 import java.util.HashMap;
 
@@ -15,6 +16,7 @@ public class Router {
         routeHashMap.put("/method_options", new MethodOptions());
         routeHashMap.put("/method_options2", new MethodOptions2());
         routeHashMap.put("/echo_body", new EchoBody());
+        routeHashMap.put("/text_response", new TextResponse());
     }
 
     public Response getResponse(String method, String path, String body) {

--- a/src/main/java/http/Router.java
+++ b/src/main/java/http/Router.java
@@ -1,6 +1,7 @@
 package http;
 
 import http.routes.*;
+import http.routes.structured_data.HTMLResponse;
 import http.routes.structured_data.TextResponse;
 
 import java.util.HashMap;
@@ -17,6 +18,7 @@ public class Router {
         routeHashMap.put("/method_options2", new MethodOptions2());
         routeHashMap.put("/echo_body", new EchoBody());
         routeHashMap.put("/text_response", new TextResponse());
+        routeHashMap.put("/html_response", new HTMLResponse());
     }
 
     public Response getResponse(String method, String path, String body) {

--- a/src/main/java/http/routes/EchoBody.java
+++ b/src/main/java/http/routes/EchoBody.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.List;
 

--- a/src/main/java/http/routes/EchoBody.java
+++ b/src/main/java/http/routes/EchoBody.java
@@ -1,9 +1,6 @@
 package http.routes;
 
-import http.HTTPStatusCodes;
-import http.Response;
-import http.ResponseBuilder;
-import http.Route;
+import http.*;
 
 import java.util.List;
 
@@ -14,7 +11,7 @@ public class EchoBody implements Route {
 
     public EchoBody() {
         CRLF = "\r\n";
-        headers = List.of("POST");
+        headers = List.of(Methods.POST.getMethod());
         headersResponse = String.format("Allow: %s", headers.get(0));
     }
 

--- a/src/main/java/http/routes/EchoBody.java
+++ b/src/main/java/http/routes/EchoBody.java
@@ -5,12 +5,10 @@ import http.*;
 import java.util.List;
 
 public class EchoBody implements Route {
-    final String CRLF;
     final List<String> headers;
     final String headersResponse;
 
     public EchoBody() {
-        CRLF = "\r\n";
         headers = List.of(Methods.POST.getMethod());
         headersResponse = String.format("Allow: %s", headers.get(0));
     }

--- a/src/main/java/http/routes/MethodOptions.java
+++ b/src/main/java/http/routes/MethodOptions.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/MethodOptions.java
+++ b/src/main/java/http/routes/MethodOptions.java
@@ -6,12 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MethodOptions implements Route {
-    final String CRLF;
     final List<String> headers;
     final String headersResponse;
 
     public MethodOptions() {
-        CRLF = "\r\n";
         headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod(), Methods.OPTIONS.getMethod());
         headersResponse = String.format("Allow: %s, %s, %s", headers.get(0), headers.get(1), headers.get(2));
     }

--- a/src/main/java/http/routes/MethodOptions2.java
+++ b/src/main/java/http/routes/MethodOptions2.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/MethodOptions2.java
+++ b/src/main/java/http/routes/MethodOptions2.java
@@ -6,12 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MethodOptions2 implements Route {
-    final String CRLF;
     final List<String> headers;
     final String headersResponse;
 
     public MethodOptions2() {
-        CRLF = "\r\n";
         headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod(), Methods.OPTIONS.getMethod(), Methods.PUT.getMethod(), Methods.POST.getMethod());
         headersResponse = String.format("Allow: %s, %s, %s, %s, %s", headers.get(0), headers.get(1), headers.get(2), headers.get(3), headers.get(4));
     }

--- a/src/main/java/http/routes/MethodOptions2.java
+++ b/src/main/java/http/routes/MethodOptions2.java
@@ -1,9 +1,6 @@
 package http.routes;
 
-import http.HTTPStatusCodes;
-import http.Response;
-import http.ResponseBuilder;
-import http.Route;
+import http.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,7 +12,7 @@ public class MethodOptions2 implements Route {
 
     public MethodOptions2() {
         CRLF = "\r\n";
-        headers = Arrays.asList("GET", "HEAD", "OPTIONS", "PUT", "POST");
+        headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod(), Methods.OPTIONS.getMethod(), Methods.PUT.getMethod(), Methods.POST.getMethod());
         headersResponse = String.format("Allow: %s, %s, %s, %s, %s", headers.get(0), headers.get(1), headers.get(2), headers.get(3), headers.get(4));
     }
     @Override

--- a/src/main/java/http/routes/Redirect.java
+++ b/src/main/java/http/routes/Redirect.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/Redirect.java
+++ b/src/main/java/http/routes/Redirect.java
@@ -9,14 +9,12 @@ public class Redirect implements Route {
     final String CRLF;
     final List<String> headers;
     final String headersResponse;
-
     final String redirectLocation;
     public Redirect() {
         CRLF = "\r\n";
         redirectLocation = "Location: http://127.0.0.1:5000/simple_get";
         headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod());
         headersResponse = String.format("%s%sAllow: %s, %s", redirectLocation, CRLF, headers.get(0), headers.get(1));
-
     }
     @Override
     public Response response(String method, String body) {

--- a/src/main/java/http/routes/Redirect.java
+++ b/src/main/java/http/routes/Redirect.java
@@ -1,9 +1,6 @@
 package http.routes;
 
-import http.HTTPStatusCodes;
-import http.Response;
-import http.ResponseBuilder;
-import http.Route;
+import http.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +14,7 @@ public class Redirect implements Route {
     public Redirect() {
         CRLF = "\r\n";
         redirectLocation = "Location: http://127.0.0.1:5000/simple_get";
-        headers = Arrays.asList("GET", "HEAD");
+        headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod());
         headersResponse = String.format("%s%sAllow: %s, %s", redirectLocation, CRLF, headers.get(0), headers.get(1));
 
     }

--- a/src/main/java/http/routes/SimpleGET.java
+++ b/src/main/java/http/routes/SimpleGET.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/SimpleGET.java
+++ b/src/main/java/http/routes/SimpleGET.java
@@ -6,12 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 
 public class SimpleGET implements Route {
-    final String CRLF;
     final List<String> headers;
     final String headersResponse;
 
     public SimpleGET() {
-        CRLF = "\r\n";
         headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod());
         headersResponse = String.format("Allow: %s, %s", headers.get(0), headers.get(1));
     }

--- a/src/main/java/http/routes/SimpleGET.java
+++ b/src/main/java/http/routes/SimpleGET.java
@@ -1,9 +1,6 @@
 package http.routes;
 
-import http.HTTPStatusCodes;
-import http.Response;
-import http.ResponseBuilder;
-import http.Route;
+import http.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,7 +12,7 @@ public class SimpleGET implements Route {
 
     public SimpleGET() {
         CRLF = "\r\n";
-        headers = Arrays.asList("GET", "HEAD");
+        headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod());
         headersResponse = String.format("Allow: %s, %s", headers.get(0), headers.get(1));
     }
     @Override

--- a/src/main/java/http/routes/SimpleGETWithBody.java
+++ b/src/main/java/http/routes/SimpleGETWithBody.java
@@ -1,9 +1,6 @@
 package http.routes;
 
-import http.HTTPStatusCodes;
-import http.Response;
-import http.ResponseBuilder;
-import http.Route;
+import http.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +14,7 @@ public class SimpleGETWithBody implements Route {
 
     public SimpleGETWithBody() {
         CRLF = "\r\n";
-        headers = Arrays.asList("GET", "HEAD");
+        headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod());
         headersResponse = String.format("Allow: %s, %s", headers.get(0), headers.get(1));
         responseBody = "Hello world";
     }

--- a/src/main/java/http/routes/SimpleGETWithBody.java
+++ b/src/main/java/http/routes/SimpleGETWithBody.java
@@ -6,14 +6,11 @@ import java.util.Arrays;
 import java.util.List;
 
 public class SimpleGETWithBody implements Route {
-    final String CRLF;
     final List<String> headers;
     final String headersResponse;
-
     final String responseBody;
 
     public SimpleGETWithBody() {
-        CRLF = "\r\n";
         headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod());
         headersResponse = String.format("Allow: %s, %s", headers.get(0), headers.get(1));
         responseBody = "Hello world";

--- a/src/main/java/http/routes/SimpleGETWithBody.java
+++ b/src/main/java/http/routes/SimpleGETWithBody.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/SimpleHEAD.java
+++ b/src/main/java/http/routes/SimpleHEAD.java
@@ -1,9 +1,6 @@
 package http.routes;
 
-import http.HTTPStatusCodes;
-import http.Response;
-import http.ResponseBuilder;
-import http.Route;
+import http.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -15,7 +12,7 @@ public class SimpleHEAD implements Route {
 
     public SimpleHEAD() {
         CRLF = "\r\n";
-        headers = Arrays.asList("HEAD", "OPTIONS");
+        headers = Arrays.asList(Methods.HEAD.getMethod(), Methods.OPTIONS.getMethod());
         headersResponse = String.format("Allow: %s, %s", headers.get(0), headers.get(1));
     }
     @Override

--- a/src/main/java/http/routes/SimpleHEAD.java
+++ b/src/main/java/http/routes/SimpleHEAD.java
@@ -1,6 +1,10 @@
 package http.routes;
 
-import http.*;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/SimpleHEAD.java
+++ b/src/main/java/http/routes/SimpleHEAD.java
@@ -6,12 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 
 public class SimpleHEAD implements Route {
-    final String CRLF;
     final List<String> headers;
     final String headersResponse;
 
     public SimpleHEAD() {
-        CRLF = "\r\n";
         headers = Arrays.asList(Methods.HEAD.getMethod(), Methods.OPTIONS.getMethod());
         headersResponse = String.format("Allow: %s, %s", headers.get(0), headers.get(1));
     }

--- a/src/main/java/http/routes/structured_data/HTMLResponse.java
+++ b/src/main/java/http/routes/structured_data/HTMLResponse.java
@@ -1,0 +1,35 @@
+package http.routes.structured_data;
+
+import http.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HTMLResponse implements Route {
+    final String CRLF;
+    final List<String> headers;
+    final String headersResponse;
+    final String textBody;
+
+    public HTMLResponse() {
+        CRLF = "\r\n";
+        headers = Arrays.asList(ContentTypes.CONTENT_TYPE_HTML.getType(), Methods.GET.getMethod(), Methods.HEAD.getMethod());
+        headersResponse = String.format("%s%sAllow: %s, %s", headers.get(0), CRLF, headers.get(1), headers.get(2));
+        textBody = "<html><body><p>HTML Response</p></body></html>";
+    }
+    @Override
+    public Response response(String method, String body) {
+        if (headers.contains(method)) {
+            return new ResponseBuilder()
+                    .withStatusCode(HTTPStatusCodes._200.getCode())
+                    .withHeader(headersResponse)
+                    .withBody(textBody)
+                    .build();
+        }
+        return new ResponseBuilder()
+                .withStatusCode(HTTPStatusCodes._405.getCode())
+                .withHeader(headersResponse)
+                .withBody("")
+                .build();
+    }
+}

--- a/src/main/java/http/routes/structured_data/HTMLResponse.java
+++ b/src/main/java/http/routes/structured_data/HTMLResponse.java
@@ -1,6 +1,11 @@
 package http.routes.structured_data;
 
-import http.*;
+import http.ContentTypes;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http/routes/structured_data/TextResponse.java
+++ b/src/main/java/http/routes/structured_data/TextResponse.java
@@ -1,19 +1,21 @@
-package http.routes;
+package http.routes.structured_data;
 
 import http.*;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class MethodOptions implements Route {
+public class TextResponse implements Route {
     final String CRLF;
     final List<String> headers;
     final String headersResponse;
+    final String textBody;
 
-    public MethodOptions() {
+    public TextResponse() {
         CRLF = "\r\n";
-        headers = Arrays.asList(Methods.GET.getMethod(), Methods.HEAD.getMethod(), Methods.OPTIONS.getMethod());
-        headersResponse = String.format("Allow: %s, %s, %s", headers.get(0), headers.get(1), headers.get(2));
+        headers = Arrays.asList(ContentTypes.CONTENT_TYPE_TEXT.getType(), Methods.GET.getMethod(), Methods.HEAD.getMethod());
+        headersResponse = String.format("%s%sAllow: %s, %s", headers.get(0), CRLF, headers.get(1), headers.get(2));
+        textBody = "text response";
     }
     @Override
     public Response response(String method, String body) {
@@ -21,7 +23,7 @@ public class MethodOptions implements Route {
             return new ResponseBuilder()
                     .withStatusCode(HTTPStatusCodes._200.getCode())
                     .withHeader(headersResponse)
-                    .withBody("")
+                    .withBody(textBody)
                     .build();
         }
         return new ResponseBuilder()

--- a/src/main/java/http/routes/structured_data/TextResponse.java
+++ b/src/main/java/http/routes/structured_data/TextResponse.java
@@ -1,6 +1,11 @@
 package http.routes.structured_data;
 
-import http.*;
+import http.ContentTypes;
+import http.HTTPStatusCodes;
+import http.Methods;
+import http.Response;
+import http.ResponseBuilder;
+import http.Route;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/http/ResponseBuilderTest.java
+++ b/src/test/java/http/ResponseBuilderTest.java
@@ -138,4 +138,14 @@ public class ResponseBuilderTest {
         assertEquals(status200ResponseWithBody, response);
     }
 
+    @Test
+    public void textResponseTest() throws IOException {
+        String requestParameters = "GET /text_response HTTP/1.1\r\n";
+        ByteArrayInputStream input = new ByteArrayInputStream(requestParameters.getBytes());
+
+        String response = ResponseBuilderTest.responseBuilderHelper(input);
+
+        String status200ResponseWithText = "HTTP/1.1 200 OK\r\nContent-Type: text/plain;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\ntext response";
+        assertEquals(status200ResponseWithText, response);
+    }
 }

--- a/src/test/java/http/ResponseBuilderTest.java
+++ b/src/test/java/http/ResponseBuilderTest.java
@@ -148,4 +148,16 @@ public class ResponseBuilderTest {
         String status200ResponseWithText = "HTTP/1.1 200 OK\r\nContent-Type: text/plain;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\ntext response";
         assertEquals(status200ResponseWithText, response);
     }
+
+    @Test
+    public void HTMLResponseTest() throws IOException {
+        String requestParameters = "GET /html_response HTTP/1.1\r\n";
+        ByteArrayInputStream input = new ByteArrayInputStream(requestParameters.getBytes());
+
+        String response = ResponseBuilderTest.responseBuilderHelper(input);
+
+        String status200ResponseWithHTML = "HTTP/1.1 200 OK\r\nContent-Type: text/html;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\n" +
+                "<html><body><p>HTML Response</p></body></html>";
+        assertEquals(status200ResponseWithHTML, response);
+    }
 }

--- a/src/test/java/http/RouterTest.java
+++ b/src/test/java/http/RouterTest.java
@@ -132,4 +132,15 @@ public class RouterTest {
         Response response = router.getResponse(method, path, body);
         assertEquals(expectedResponse, response.responseString());
     }
+    @Test
+    public void JSONResponseRouteTest() {
+        method = "GET";
+        path = "/json_response";
+        body = "";
+
+        expectedResponse = "HTTP/1.1 200 OK\r\nContent-Type: text/html;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\n" +
+                "<html><body><p>HTML Response</p></body></html>";
+        Response response = router.getResponse(method, path, body);
+        assertEquals(expectedResponse, response.responseString());
+    }
 }

--- a/src/test/java/http/RouterTest.java
+++ b/src/test/java/http/RouterTest.java
@@ -108,4 +108,15 @@ public class RouterTest {
         Response response = router.getResponse(method, path, body);
         assertEquals(expectedResponse, response.responseString());
     }
+
+    @Test
+    public void textResponseRouteTest() {
+        method = "GET";
+        path = "/text_response";
+        body = "";
+
+        expectedResponse = "HTTP/1.1 200 OK\r\nContent-Type: text/plain;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\ntext response";
+        Response response = router.getResponse(method, path, body);
+        assertEquals(expectedResponse, response.responseString());
+    }
 }

--- a/src/test/java/http/RouterTest.java
+++ b/src/test/java/http/RouterTest.java
@@ -115,7 +115,20 @@ public class RouterTest {
         path = "/text_response";
         body = "";
 
-        expectedResponse = "HTTP/1.1 200 OK\r\nContent-Type: text/plain;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\ntext response";
+        expectedResponse = "HTTP/1.1 200 OK\r\nContent-Type: text/plain;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\n" +
+                "text response";
+        Response response = router.getResponse(method, path, body);
+        assertEquals(expectedResponse, response.responseString());
+    }
+
+    @Test
+    public void HTMLResponseRouteTest() {
+        method = "GET";
+        path = "/html_response";
+        body = "";
+
+        expectedResponse = "HTTP/1.1 200 OK\r\nContent-Type: text/html;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\n" +
+                "<html><body><p>HTML Response</p></body></html>";
         Response response = router.getResponse(method, path, body);
         assertEquals(expectedResponse, response.responseString());
     }

--- a/src/test/java/http/RouterTest.java
+++ b/src/test/java/http/RouterTest.java
@@ -132,15 +132,5 @@ public class RouterTest {
         Response response = router.getResponse(method, path, body);
         assertEquals(expectedResponse, response.responseString());
     }
-    @Test
-    public void JSONResponseRouteTest() {
-        method = "GET";
-        path = "/json_response";
-        body = "";
 
-        expectedResponse = "HTTP/1.1 200 OK\r\nContent-Type: text/html;charset=utf-8\r\nAllow: GET, HEAD\r\n\r\n" +
-                "<html><body><p>HTML Response</p></body></html>";
-        Response response = router.getResponse(method, path, body);
-        assertEquals(expectedResponse, response.responseString());
-    }
 }


### PR DESCRIPTION
Implements first two features of `01_Structured_Data` below by adding new Routes in `routes.structured_data`
```
 Scenario: Returning a text response
    Given I make a GET request to "/text_response"
    Then my response should have status code 200
    And my response should return text
    And my response should have a text body

Scenario: Returning an HTML response
    Given I make a GET request to "/html_response"
    Then my response should have status code 200
    And my response should return HTML
    And my response should have an HTML body
```

Refactors app to use enums for `CONTENT_TYPES` & `METHODS`